### PR TITLE
Change the design of position on backlog item

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -13,6 +13,8 @@
  *= require_tree .
  */
 
+$orange: #FFAA17
+
 body
   background-image: url('/squairy_light.png')
 
@@ -23,11 +25,32 @@ div.content
 
 h1
   padding-bottom: 10px
+  position: relative
+  left: -35px
 
-span.dates
-  font-size: 12px
+div.dates
+  padding-top: 25px
+  font-size: 14px
   span.created
     padding-right: 35px
 
 p.description
   padding-top: 20px
+
+span.position
+  background: $orange
+  border-radius: 0.8em
+  -moz-border-radius: 0.8em
+  -webkit-border-radius: 0.8em
+  color: #FFF
+  display: inline-block
+  font-weight: bold
+  line-height: 1.6em
+  margin-right: 5px
+  text-align: center
+  width: 1.6em
+  font-size: 35px
+  position: relative
+  left: -50px
+  top: 3px
+  float: left

--- a/app/views/backlog_items/show.html.erb
+++ b/app/views/backlog_items/show.html.erb
@@ -1,12 +1,7 @@
+<span class='position'><%= @backlog_item.position %></span>
+
 <h1><%= @backlog_item.name %></h1>
 
-<span class='dates muted'>
-  <span class='created'><strong>Created by <%= @backlog_item.creator.email %> on </strong> <%= l @backlog_item.created_at, :format => :notime %></span>
-
-  <span class='updated'><strong>Last Updated:</strong> <%= l @backlog_item.updated_at, :format => :notime %></span>
-</span>
-
-<span><strong>Position</strong> <%= @backlog_item.position %></span>
 <span><strong>Status</strong> <%= @backlog_item.status %></span>
 
 <p class='description'><strong>Description -</strong> <%= @backlog_item.description %></p>
@@ -19,4 +14,8 @@
   <% @backlog_item.comments.each do |comment| %>
     <p><%= comment.comment %></p>
   <% end %>
+</div>
+
+<div class='dates muted'>
+  Created by <strong><%= @backlog_item.creator.email %></strong> on <%= l @backlog_item.created_at, :format => :notime %> and <strong>last updated</strong> <%= l @backlog_item.updated_at, :format => :notime %>
 </div>


### PR DESCRIPTION
Right now this looks like the following

The position is in an orange circle just to the left of the name of the backlog item

![screen shot 2013-07-20 at 10 11 35 pm](https://f.cloud.github.com/assets/100039/831261/1c25a3ee-f1c4-11e2-9889-2703f11a9f20.png)
